### PR TITLE
Some UI fixes

### DIFF
--- a/oscd-designer.ts
+++ b/oscd-designer.ts
@@ -609,7 +609,6 @@ export default class Designer extends LitElement {
                     const element =
                       this.templateElements.ConductingEquipment!.cloneNode() as Element;
                     element.setAttribute('type', eqType);
-                    element.setAttribute('name', `${eqType}1`);
                     this.startPlacing(element);
                   }}
                   style="--mdc-theme-secondary: #fff; --mdc-theme-on-secondary: rgb(0, 0, 0 / 0.83)"

--- a/sld-editor.ts
+++ b/sld-editor.ts
@@ -1009,7 +1009,7 @@ export class SLDEditor extends LitElement {
           g.bay > rect {
             shape-rendering: crispEdges;
           }
-          section:not(:hover) .preview {
+          svg:not(:hover) .preview {
             visibility: hidden;
           }
           .preview {
@@ -1055,7 +1055,12 @@ export class SLDEditor extends LitElement {
           this.substation.querySelectorAll(
             'VoltageLevel, Bay, ConductingEquipment'
           )
-        ).map(element => this.renderLabel(element))}
+        )
+          .filter(
+            e =>
+              !this.placing || e.closest(this.placing.tagName) !== this.placing
+          )
+          .map(element => this.renderLabel(element))}
         ${placingLabelTarget}
       </svg>
       ${menu} ${coordinateTooltip}
@@ -1158,7 +1163,7 @@ export class SLDEditor extends LitElement {
       events = 'all';
       handleClick = () => this.dispatchEvent(newStartPlaceLabelEvent(element));
     }
-    const id = identity(element);
+    const id = element.parentElement ? identity(element) : 'placing...';
     return svg`<g class="label" id="label:${id}">
         <text x="${x + 0.1}" y="${y - 0.2}"
           @mousedown=${preventDefault}
@@ -1296,6 +1301,13 @@ export class SLDEditor extends LitElement {
             ? Array.from(bayOrVL.querySelectorAll('ConnectivityNode'))
                 .filter(child => child.getAttribute('name') !== 'grounded')
                 .map(cNode => this.renderConnectivityNode(cNode))
+            : nothing
+        }
+        ${
+          preview
+            ? Array.from(bayOrVL.querySelectorAll('Bay, ConductingEquipment'))
+                .concat(bayOrVL)
+                .map(element => this.renderLabel(element))
             : nothing
         }
       ${placingTarget}
@@ -1464,7 +1476,8 @@ export class SLDEditor extends LitElement {
       ${bottomConnector}
       ${bottomIndicator}
       ${bottomGrounded}
-    </g>`;
+    </g>
+    <g class="preview">${preview ? this.renderLabel(equipment) : nothing}</g>`;
   }
 
   renderBusBar(busBar: Element) {
@@ -1662,6 +1675,9 @@ export class SLDEditor extends LitElement {
     }
 
     .hidden {
+      display: none;
+    }
+    svg:not(:hover) ~ .coordinates {
       display: none;
     }
     .coordinates {

--- a/sld-editor.ts
+++ b/sld-editor.ts
@@ -783,7 +783,7 @@ export class SLDEditor extends LitElement {
           const nav = (
             this.parentElement!.getRootNode() as ShadowRoot
           ).querySelector('nav')!;
-          const navHeight = nav.offsetHeight + 12;
+          const navHeight = nav.offsetHeight + 8;
           await this.updateComplete;
           const { bottom, right } = menu.getBoundingClientRect();
           if (bottom > window.innerHeight - navHeight) {
@@ -880,7 +880,7 @@ export class SLDEditor extends LitElement {
     </div>`;
 
     const connectionPreview = [];
-    if (this.connecting) {
+    if (this.connecting?.equipment.closest('Substation') === this.substation) {
       const { equipment, path, terminal } = this.connecting;
       let i = 0;
       while (i < path.length - 2) {

--- a/util.ts
+++ b/util.ts
@@ -275,6 +275,7 @@ function uniqueName(element: Element, parent: Element): string {
 
   const baseName =
     element.getAttribute('name')?.replace(/[0-9]*$/, '') ??
+    element.getAttribute('type') ??
     element.tagName.charAt(0);
   let index = 1;
   function hasName(child: Element) {


### PR DESCRIPTION
This fixes two bugs related to previews (of labels and connections respectively) being shown in the wrong single line diagrams. Connections were shown in all of them, while labels were only shown in the substation where they currently live, even when moving elements to another substation.