### PR TITLE
fix: reposition palette above substation (closes #119)

### DIFF
--- a/oscd-editor-sld.ts
+++ b/oscd-editor-sld.ts
@@ -648,7 +648,6 @@ export default class OscdEditorSld extends ScopedElementsMixin(LitElement) {
     nav {
       user-select: none;
       position: sticky;
-      top: 68px;
       left: 16px;
       width: fit-content;
       max-width: calc(100vw - 32px);


### PR DESCRIPTION
I think this css rule was unnecessary. The palette seems to be correctly positioned in the previous oscd-shell/open-scd-core interface as well as the new one.

This will correctly place the palette above the first Substation element's controls:

<img width="1550" height="203" alt="image" src="https://github.com/user-attachments/assets/0e36b7ff-a759-42da-a75b-072f79feb49d" />
