### PR TITLE
feat: add action for importing bay typicals

### DIFF
--- a/demo/sample.scd
+++ b/demo/sample.scd
@@ -22,4 +22,43 @@
       </Bay>
     </VoltageLevel>
   </Substation>
+  <IED name="test" manufacturer="OpenSCD">
+    <Services>
+      <ConfLdName />
+    </Services>
+    <AccessPoint name="AP1">
+      <Server>
+        <Authentication/>
+        <LDevice inst="LD1">
+          <LN0 lnClass="LLN0" inst="" lnType="PlaceholderLLN0"/>
+        </LDevice>
+      </Server>
+    </AccessPoint>
+  </IED>
+  <IED name="test2" manufacturer="OpenSCD">
+    <Services>
+      <ConfLdName />
+    </Services>
+    <AccessPoint name="AP1">
+      <Server>
+        <Authentication/>
+        <LDevice inst="LD1">
+          <LN0 lnClass="LLN0" inst="" lnType="PlaceholderLLN0"/>
+        </LDevice>
+      </Server>
+    </AccessPoint>
+  </IED>
+  <IED name="test3" manufacturer="OpenSCD">
+    <Services>
+      <ConfLdName />
+    </Services>
+    <AccessPoint name="AP1">
+      <Server>
+        <Authentication/>
+        <LDevice inst="LD1">
+          <LN0 lnClass="LLN0" inst="" lnType="PlaceholderLLN0"/>
+        </LDevice>
+      </Server>
+    </AccessPoint>
+  </IED>
 </SCL>

--- a/oscd-editor-sld.ts
+++ b/oscd-editor-sld.ts
@@ -51,10 +51,10 @@ export default class OscdEditorSld extends ScopedElementsMixin(LitElement) {
     'sld-editor': SldEditor,
   };
 
-  @property()
+  @property({ type: Object })
   doc!: XMLDocument;
 
-  @property()
+  @property({ type: Number })
   docVersion: number = -1;
 
   @state()
@@ -90,6 +90,8 @@ export default class OscdEditorSld extends ScopedElementsMixin(LitElement) {
   @query('#iedMenu') iedMenu?: Menu;
 
   @query('sld-editor') sldEditor?: SldEditor;
+
+  @query('#bayTypicalFileInput') bayTypicalFileInput?: HTMLInputElement;
 
   zoomIn() {
     this.gridSize += 3;
@@ -156,6 +158,28 @@ export default class OscdEditorSld extends ScopedElementsMixin(LitElement) {
   convertSldAttributes() {
     const convertEdits = convertSldLayout(this.doc, this.nsp);
     this.dispatchEvent(newEditEventV2(convertEdits));
+  }
+
+  /** Loads the file `event.target.files[0]` into [[`src`]] as a `blob:...`. */
+  async importBayTypical(event: Event): Promise<void> {
+    const file = (<HTMLInputElement | null>event.target)?.files?.item(0);
+    if (!file) return;
+
+    const fileBlob = await file.text();
+
+    const bayTypicalDoc = new DOMParser().parseFromString(
+      fileBlob,
+      'application/xml'
+    );
+
+    const convertEdits = convertSldLayout(bayTypicalDoc, this.nsp);
+    this.dispatchEvent(newEditEventV2(convertEdits));
+
+    const bayTypical = bayTypicalDoc.querySelector('Bay');
+
+    if (bayTypical && this.sldEditor) {
+      this.sldEditor.startPlacingBayTypical(bayTypical);
+    }
   }
 
   render() {
@@ -264,6 +288,22 @@ export default class OscdEditorSld extends ScopedElementsMixin(LitElement) {
               style="--mdc-theme-secondary: #F5E214;"
             >
               ${voltageLevelIcon}
+            </mwc-fab>
+            <mwc-fab
+              icon="upload_file"
+              mini
+              label="Import Bay Typical"
+              title="Import Bay Typical"
+              @click=${(evt: Event) => {
+                evt.stopImmediatePropagation();
+                this.bayTypicalFileInput?.click();
+              }}
+            >
+              <input
+                id="bayTypicalFileInput"
+                type="file"
+                @change="${this.importBayTypical}"
+              />
             </mwc-fab>
             ${ieds.length > 0 || unusedIeds.length > 0
               ? html`<mwc-fab

--- a/sld-editor.ts
+++ b/sld-editor.ts
@@ -2,9 +2,9 @@ import { html, LitElement } from 'lit';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { customElement, property, state } from 'lit/decorators.js';
 import { ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
-import { newEditEventV2 } from '@openscd/oscd-api/utils.js';
+import { newEditEvent, newEditEventV2 } from '@openscd/oscd-api/utils.js';
 import { EditV2, SetAttributes } from '@openscd/oscd-api';
-import { getReference } from '@openscd/scl-lib';
+import { getReference, insertIed } from '@openscd/scl-lib';
 
 import { SldSubstationEditor } from './sld-substation-editor.js';
 
@@ -91,9 +91,9 @@ export class SldEditor extends ScopedElementsMixin(LitElement) {
     'sld-substation-editor': SldSubstationEditor,
   };
 
-  @property() doc!: XMLDocument;
+  @property({ type: Object }) doc!: XMLDocument;
 
-  @property()
+  @property({ type: Number })
   get docVersion(): number {
     return this._docVersion;
   }
@@ -110,9 +110,17 @@ export class SldEditor extends ScopedElementsMixin(LitElement) {
 
   @property({ type: Boolean }) disabled = false;
 
-  @property() selectable: string[] = [];
+  @property({ type: Array }) selectable: string[] = [];
 
-  @property() highlight: { id: string; style: Style }[] = [];
+  @property({ type: Array }) highlight: { id: string; style: Style }[] = [];
+
+  @property({ type: Boolean })
+  showIeds?: boolean;
+
+  public startPlacingBayTypical = (element: Element) => {
+    this.startPlacing(element);
+    this.placingBayTypical = element;
+  };
 
   @state() gridSize = 32;
 
@@ -124,14 +132,14 @@ export class SldEditor extends ScopedElementsMixin(LitElement) {
 
   @state() placing?: Element;
 
+  @state()
+  placingBayTypical?: Element;
+
   @state() placingOffset: Point = [0, 0];
 
   @state() placingLabel?: Element;
 
   @state() showLabels: boolean = true;
-
-  @property()
-  showIeds?: boolean;
 
   @state()
   connecting?: {
@@ -456,6 +464,15 @@ export class SldEditor extends ScopedElementsMixin(LitElement) {
           })
         );
       }
+    } else if (this.placingBayTypical && this.placing) {
+      const scl = this.doc.querySelector('SCL')!;
+      const ieds = this.placing.ownerDocument.querySelectorAll(':root > IED');
+
+      ieds.forEach(ied => {
+        this.dispatchEvent(newEditEvent(insertIed(scl, ied)));
+      });
+
+      this.placingBayTypical = undefined;
     }
 
     const oldParent = element.parentElement;
@@ -644,7 +661,7 @@ export class SldEditor extends ScopedElementsMixin(LitElement) {
     this.dispatchEvent(newEditEventV2(edits));
   }
 
-  render(): unknown {
+  render() {
     return html`${Array.from(
       this.doc.querySelectorAll(':root > Substation')
     ).map(

--- a/util.ts
+++ b/util.ts
@@ -162,10 +162,7 @@ function sldAttributes(element: Element, nsPrefix?: string): Element | null {
   priv.setAttribute('type', privType);
   element.insertBefore(priv, getReference(element, 'Private'));
 
-  const sldAttrsNew = doc.createElementNS(
-    sldNs,
-    `${nsPrefix}:SLDAttributes`
-  );
+  const sldAttrsNew = doc.createElementNS(sldNs, `${nsPrefix}:SLDAttributes`);
   priv.insertBefore(sldAttrsNew, null);
 
   return sldAttrsNew;


### PR DESCRIPTION
This is a cut down version of the original feature, which only imports a bay-typical file and allows the user to position the bay in the diagram. 

This is a short-medium term fix until such a time as we have a more holistic solution for importing/including artifacts to the diagram. 